### PR TITLE
Limit double tweet posts

### DIFF
--- a/plugins/twitter/twitter.go
+++ b/plugins/twitter/twitter.go
@@ -40,7 +40,7 @@ func load(consumerKey, consumerSecret, accessToken, accessSecret string, filter 
 					switch m := msg.(type) {
 					case *twitter.Tweet:
 						if channel, ok := filter[m.User.IDStr]; ok {
-							if filter[m.InReplyToUserIDStr] not channel {
+							if filter[m.InReplyToUserIDStr] != channel {
 								twitterUrl := fmt.Sprintf("https://twitter.com/%s/status/%s", m.User.ScreenName, m.IDStr)
 								chanId, err := bot.GetChannelId(channel)
 								if err != nil {

--- a/plugins/twitter/twitter.go
+++ b/plugins/twitter/twitter.go
@@ -40,13 +40,15 @@ func load(consumerKey, consumerSecret, accessToken, accessSecret string, filter 
 					switch m := msg.(type) {
 					case *twitter.Tweet:
 						if channel, ok := filter[m.User.IDStr]; ok {
-							twitterUrl := fmt.Sprintf("https://twitter.com/%s/status/%s", m.User.ScreenName, m.IDStr)
-							chanId, err := bot.GetChannelId(channel)
-							if err != nil {
-								log.WithField("err", err).Error("unable to find channel.")
-								continue
+							if filter[m.InReplyToUserIDStr] not channel {
+								twitterUrl := fmt.Sprintf("https://twitter.com/%s/status/%s", m.User.ScreenName, m.IDStr)
+								chanId, err := bot.GetChannelId(channel)
+								if err != nil {
+									log.WithField("err", err).Error("unable to find channel.")
+									continue
+								}
+								bot.Say(chanId, twitterUrl)
 							}
-							bot.Say(chanId, twitterUrl)
 						}
 					}
 				}

--- a/plugins/twitter/twitter.go
+++ b/plugins/twitter/twitter.go
@@ -40,7 +40,7 @@ func load(consumerKey, consumerSecret, accessToken, accessSecret string, filter 
 					switch m := msg.(type) {
 					case *twitter.Tweet:
 						if channel, ok := filter[m.User.IDStr]; ok {
-							if filter[m.InReplyToUserIDStr] != channel {
+							if replyChannel, ok := filter[m.InReplyToUserIDStr]; !ok || channel != replyChannel {
 								twitterUrl := fmt.Sprintf("https://twitter.com/%s/status/%s", m.User.ScreenName, m.IDStr)
 								chanId, err := bot.GetChannelId(channel)
 								if err != nil {


### PR DESCRIPTION
Prevent duplicate retweets if the original poster is also monitored in the channel.