### PR TITLE
replace deprecated satori/go.uuid with gofrs/go.uuid

### DIFF
--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -14,10 +14,10 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	"github.com/gofrs/go.uuid"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-github/github"
 	"github.com/jirwin/quadlek/quadlek"
-	"github.com/satori/go.uuid"
 	"golang.org/x/oauth2"
 	githuboauth "golang.org/x/oauth2/github"
 )

--- a/plugins/spotify/spotify.go
+++ b/plugins/spotify/spotify.go
@@ -14,9 +14,9 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	"github.com/gofrs/go.uuid"
 	"github.com/golang/protobuf/proto"
 	"github.com/jirwin/quadlek/quadlek"
-	"github.com/satori/go.uuid"
 	"github.com/zmb3/spotify"
 	"golang.org/x/oauth2"
 )


### PR DESCRIPTION
Fixes #11 

per https://github.com/gofrs/uuid/releases/tag/v2.0.0

There is a community fork of this cookbook now, making for an even easier upgrade path.