### PR TITLE
Include the http.ResponseWriter in the message from the webhook handler.

### DIFF
--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"reflect"
@@ -226,6 +227,12 @@ func githubAuthorizeWebhook(ctx context.Context, whChannel <-chan *quadlek.Webho
 	for {
 		select {
 		case whMsg := <-whChannel:
+			// respond to webhook
+			whMsg.ResponseWriter.WriteHeader(http.StatusOK)
+			whMsg.ResponseWriter.Write([]byte{})
+			whMsg.Done <- true
+
+			// process webhook
 			state := whMsg.Request.FormValue("state")
 			whMsg.Request.Body.Close()
 

--- a/plugins/spotify/spotify.go
+++ b/plugins/spotify/spotify.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"time"
@@ -181,6 +182,12 @@ func spotifyAuthorizeWebhook(ctx context.Context, whChannel <-chan *quadlek.Webh
 	for {
 		select {
 		case whMsg := <-whChannel:
+			// respond to webhook
+			whMsg.ResponseWriter.WriteHeader(http.StatusOK)
+			whMsg.ResponseWriter.Write([]byte{})
+			whMsg.Done <- true
+
+			// process webhook
 			query := whMsg.Request.URL.Query()
 			stateId, ok := query["state"]
 			whMsg.Request.Body.Close()

--- a/quadlek/plugins.go
+++ b/quadlek/plugins.go
@@ -173,9 +173,11 @@ type Webhook interface {
 
 // WebhookMsg is the struct that is sent to the plugin's channel
 type WebhookMsg struct {
-	Bot     *Bot
-	Request *http.Request
-	Store   *Store
+	Bot            *Bot
+	Request        *http.Request
+	ResponseWriter http.ResponseWriter
+	Store          *Store
+	Done           chan bool
 }
 
 // registeredWebhook is the internal struct that represents a registered webhook
@@ -428,9 +430,10 @@ func (b *Bot) dispatchWebhook(webhook *PluginWebhook) {
 	}
 
 	wh.Webhook.Channel() <- &WebhookMsg{
-		Bot:     b,
-		Request: webhook.Request,
-		Store:   b.getStore(wh.PluginId),
+		Bot:            b,
+		Request:        webhook.Request,
+		ResponseWriter: webhook.ResponseWriter,
+		Store:          b.getStore(wh.PluginId),
 	}
 }
 


### PR DESCRIPTION
This offloads the entire webhook handler to the relevant plugin.

This is useful if you need to actually write responses or set different return codes.

This also dodges the main event loop now: handlers are run in their own goroutine anyway, but we can't return from the handler until we've done everything we need to with the responseWriter, so we require explicit cooperation from plugins to signal when they are done. (Or we just time them out)

This is a pretty big hole to poke in whatever abstraction layer we had - we could make an interface for plugins to communicate back to the handler (I think headers, bytes, and status code would probably be enough). But, this works?

